### PR TITLE
Simplified view for PNG RISE to consume the pages read table

### DIFF
--- a/AdditionalMetadataBackup/03 Views - for a Generic Dashboard/pages_read-combined.sql
+++ b/AdditionalMetadataBackup/03 Views - for a Generic Dashboard/pages_read-combined.sql
@@ -1,0 +1,13 @@
+-- Bloom 1.x (through 1.3, at least) separated analytics out into different tables.
+-- That makes it hard to count the beta, which is substantial (currently 1/3 of use).
+-- at this point we don't have an "alpha" version, and probably should keep that out of any reporting.
+-- This table just puts them together and adds a column for channel (which is also already part of the version column)
+
+CREATE OR REPLACE VIEW bloomreader.pages_read_combined AS
+SELECT *,
+    'release' channel
+    FROM bloomreader.pages_read
+UNION
+SELECT *, 
+    'beta' channel
+    FROM bloomreaderbeta.pages_read

--- a/queries/PNG-RISE Pages Read.sql
+++ b/queries/PNG-RISE Pages Read.sql
@@ -1,0 +1,22 @@
+SELECT 
+    a."timestamp" as time_stamp,
+    
+    CAST(date_part('hour', a.timestamp AT TIME ZONE 'PGT') AS INTEGER) as time_png_hour,
+    to_char(a.timestamp AT TIME ZONE 'PGT',  'day') as time_png_weekday,
+        a.audio_pages as pages_read_audio,
+    a.non_audio_pages as pages_read_nonaudio,
+    a.audio_pages + a.non_audio_pages as pages_read,
+    a.anonymous_id as device_unique_id,
+    a.context_traits_user_id as device_project_hardware_code, -- comes from deviceId.json, if found on the device
+    a.context_major_minor as bloom_reader_version,
+    a.title as book_title,
+    a.branding_project_name as book_branding, -- even though they will all say "RISE PNG", this gives client confidence in what he is seeing
+    a.content_lang as book_language,
+    a.total_numbered_pages as book_pages,
+
+    a.last_numbered_page_read as finished_reading_book
+   FROM bloomreader.pages_read a
+    WHERE a.branding_project_name = 'PNG-RISE' 
+    AND (a.location_uid IN ( SELECT b.loc_uid
+           FROM countryregioncitylu b
+          WHERE b.country_name = 'Papua New Guinea'))


### PR DESCRIPTION
Not a "view" yet... doesn't matter as we aren't wiring this to a dashboard yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/analytics-postgresql/10)
<!-- Reviewable:end -->
